### PR TITLE
Replace Jellyseerr with Seerr (unified Overseerr/Jellyseerr successor)

### DIFF
--- a/nix/hosts/theater/default.nix
+++ b/nix/hosts/theater/default.nix
@@ -64,7 +64,7 @@
     13378 # audiobookshelf
     8081 # qbittorrent webui
     8096 # jellyfin
-    5055 # jellyseerr
+    5055 # seerr
     6767 # bazarr
   ];
 

--- a/nix/hosts/theater/docker-compose.yaml
+++ b/nix/hosts/theater/docker-compose.yaml
@@ -97,15 +97,16 @@ services:
       - ${DATA_DIR}/media:/data/media
     restart: unless-stopped
 
-  jellyseerr:
-    image: fallenbagel/jellyseerr:latest
-    container_name: jellyseerr
+  seerr:
+    image: ghcr.io/seerr-team/seerr:latest
+    init: true
+    container_name: seerr
     ports:
       - "5055:5055"
     environment:
       - TZ=${TZ}
     volumes:
-      - ${APPDATA_DIR}/jellyseerr:/app/config
+      - ${APPDATA_DIR}/seerr:/app/config
     restart: unless-stopped
 
   bazarr:

--- a/nix/hosts/theater/make_dirs.sh
+++ b/nix/hosts/theater/make_dirs.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 sudo mkdir -p /data/{torrents/{movies,tv,books,audiobooks,completed,incomplete},usenet/{complete,incomplete},media/{movies,tv,books,audiobooks}}
-sudo mkdir -p /docker/appdata/{gluetun,qbittorrent,prowlarr,radarr,sonarr,flaresolverr,jellyfin,jellyseerr,audiobookshelf,calibre,calibre-web,sabnzbd}
+sudo mkdir -p /docker/appdata/{gluetun,qbittorrent,prowlarr,radarr,sonarr,flaresolverr,jellyfin,seerr,audiobookshelf,calibre,calibre-web,sabnzbd}
 sudo chown -R 1000:1000 /data
 sudo chown -R 1000:1000 /docker/appdata
 sudo chmod -R 775 /data


### PR DESCRIPTION
- Swap Docker image from fallenbagel/jellyseerr to ghcr.io/seerr-team/seerr
- Add init: true (required since Seerr runs as non-root node user)
- Update appdata directory name from jellyseerr to seerr
- Update firewall comment in default.nix

https://claude.ai/code/session_01DMhPN47x72jyfxUCr9VgSi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to service renaming/image swap and config path changes for a single container; main risk is losing/mispointing existing `jellyseerr` config data during migration.
> 
> **Overview**
> Replaces `jellyseerr` with `seerr` in the theater media Docker Compose stack by switching to the `ghcr.io/seerr-team/seerr` image, adding `init: true`, and updating the config volume to use a new `${APPDATA_DIR}/seerr` directory.
> 
> Updates supporting host config to match, including the appdata directory creation in `make_dirs.sh` and the firewall port comment in `default.nix` for TCP `5055`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 316ea5503d54068feaf35c57fa304e9544e7f31f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->