### PR TITLE
Add profilarr to docker media stack

### DIFF
--- a/nix/hosts/theater/default.nix
+++ b/nix/hosts/theater/default.nix
@@ -66,6 +66,7 @@
     8096 # jellyfin
     5055 # seerr
     6767 # bazarr
+    6868 # profilarr
   ];
 
   # Server-specific packages

--- a/nix/hosts/theater/docker-compose.yaml
+++ b/nix/hosts/theater/docker-compose.yaml
@@ -138,6 +138,19 @@ services:
       - ${DATA_DIR}/usenet:/data/usenet
     restart: unless-stopped
 
+  profilarr:
+    image: ghcr.io/dictionarry-hub/profilarr:latest
+    container_name: profilarr
+    ports:
+      - "6868:6868"
+    environment:
+      - PUID=${PUID}
+      - PGID=${PGID}
+      - TZ=${TZ}
+    volumes:
+      - ${APPDATA_DIR}/profilarr:/config
+    restart: unless-stopped
+
   watchtower:
     image: containrrr/watchtower:latest
     container_name: watchtower

--- a/nix/hosts/theater/make_dirs.sh
+++ b/nix/hosts/theater/make_dirs.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 sudo mkdir -p /data/{torrents/{movies,tv,books,audiobooks,completed,incomplete},usenet/{complete,incomplete},media/{movies,tv,books,audiobooks}}
-sudo mkdir -p /docker/appdata/{gluetun,qbittorrent,prowlarr,radarr,sonarr,flaresolverr,jellyfin,seerr,audiobookshelf,calibre,calibre-web,sabnzbd}
+sudo mkdir -p /docker/appdata/{gluetun,qbittorrent,prowlarr,radarr,sonarr,flaresolverr,jellyfin,seerr,audiobookshelf,calibre,calibre-web,sabnzbd,profilarr}
 sudo chown -R 1000:1000 /data
 sudo chown -R 1000:1000 /docker/appdata
 sudo chmod -R 775 /data


### PR DESCRIPTION
Profilarr manages and syncs custom formats and quality profiles
for Radarr/Sonarr instances via a web UI on port 6868.

https://claude.ai/code/session_015dfviesjgumzDHuF6R8ien

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new container and opens one additional firewall port; impact is limited to the theater host’s media stack configuration.
> 
> **Overview**
> Adds `profilarr` to the theater host’s docker-compose media stack, with a persistent config volume and a `6868:6868` port mapping.
> 
> Updates host networking to allow inbound TCP `6868`, and extends `make_dirs.sh` to create the `/docker/appdata/profilarr` directory for container state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc22ce49bd14e0d50940990078c5993a13c0b549. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->