### PR TITLE
Update profilarr Docker image to santiagosayshey/profilarr

### DIFF
--- a/nix/hosts/theater/docker-compose.yaml
+++ b/nix/hosts/theater/docker-compose.yaml
@@ -139,7 +139,7 @@ services:
     restart: unless-stopped
 
   profilarr:
-    image: ghcr.io/dictionarry-hub/profilarr:latest
+    image: santiagosayshey/profilarr:latest
     container_name: profilarr
     ports:
       - "6868:6868"


### PR DESCRIPTION
https://claude.ai/code/session_01L2CeZwybKJFH25e9F9FeEN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line deploy configuration change; main risk is behavior/compatibility differences introduced by the new image publisher/tag.
> 
> **Overview**
> Updates the `profilarr` service in `nix/hosts/theater/docker-compose.yaml` to pull `santiagosayshey/profilarr:latest` instead of `ghcr.io/dictionarry-hub/profilarr:latest`, leaving ports, volumes, and environment unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 861356747a3aab5c1d8b1955dc0ee8f8eb5f51e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->