### PR TITLE
Add Homarr dashboard to media stack

### DIFF
--- a/nix/hosts/theater/.env.example
+++ b/nix/hosts/theater/.env.example
@@ -10,3 +10,7 @@ APPDATA_DIR=/docker/appdata
 OPENVPN_USER=REPLACE_ME
 OPENVPN_PASSWORD=REPLACE_ME
 SERVER_COUNTRIES=United States
+
+# Homarr encryption key (64-char hex string)
+# Generate with: ./generate-homarr-key.sh
+HOMARR_SECRET_ENCRYPTION_KEY=REPLACE_ME

--- a/nix/hosts/theater/default.nix
+++ b/nix/hosts/theater/default.nix
@@ -88,6 +88,7 @@
     gnumake
     cmake
     gcc
+    openssl
   ];
 
   services.noctalia-shell.enable = true;

--- a/nix/hosts/theater/default.nix
+++ b/nix/hosts/theater/default.nix
@@ -67,6 +67,7 @@
     5055 # seerr
     6767 # bazarr
     6868 # profilarr
+    7575 # homarr
   ];
 
   # Server-specific packages

--- a/nix/hosts/theater/docker-compose.yaml
+++ b/nix/hosts/theater/docker-compose.yaml
@@ -151,6 +151,19 @@ services:
       - ${APPDATA_DIR}/profilarr:/config
     restart: unless-stopped
 
+  homarr:
+    image: ghcr.io/homarr-labs/homarr:latest
+    container_name: homarr
+    ports:
+      - "7575:7575"
+    environment:
+      - TZ=${TZ}
+      - SECRET_ENCRYPTION_KEY=${HOMARR_SECRET_ENCRYPTION_KEY}
+    volumes:
+      - ${APPDATA_DIR}/homarr:/appdata
+      - /var/run/docker.sock:/var/run/docker.sock
+    restart: unless-stopped
+
   watchtower:
     image: containrrr/watchtower:latest
     container_name: watchtower

--- a/nix/hosts/theater/generate-homarr-key.sh
+++ b/nix/hosts/theater/generate-homarr-key.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Generates a 64-character hex encryption key for Homarr
+# and updates it in the .env file.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENV_FILE="$SCRIPT_DIR/.env"
+
+KEY=$(openssl rand -hex 32)
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "Error: $ENV_FILE not found. Copy .env.example to .env first." >&2
+  exit 1
+fi
+
+if grep -q '^HOMARR_SECRET_ENCRYPTION_KEY=' "$ENV_FILE"; then
+  sed -i "s|^HOMARR_SECRET_ENCRYPTION_KEY=.*|HOMARR_SECRET_ENCRYPTION_KEY=$KEY|" "$ENV_FILE"
+else
+  echo "HOMARR_SECRET_ENCRYPTION_KEY=$KEY" >> "$ENV_FILE"
+fi
+
+echo "Homarr encryption key set in $ENV_FILE"

--- a/nix/hosts/theater/make_dirs.sh
+++ b/nix/hosts/theater/make_dirs.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 sudo mkdir -p /data/{torrents/{movies,tv,books,audiobooks,completed,incomplete},usenet/{complete,incomplete},media/{movies,tv,books,audiobooks}}
-sudo mkdir -p /docker/appdata/{gluetun,qbittorrent,prowlarr,radarr,sonarr,flaresolverr,jellyfin,seerr,audiobookshelf,calibre,calibre-web,sabnzbd,profilarr}
+sudo mkdir -p /docker/appdata/{gluetun,qbittorrent,prowlarr,radarr,sonarr,flaresolverr,jellyfin,seerr,audiobookshelf,calibre,calibre-web,sabnzbd,profilarr,homarr}
 sudo chown -R 1000:1000 /data
 sudo chown -R 1000:1000 /docker/appdata
 sudo chmod -R 775 /data


### PR DESCRIPTION
https://claude.ai/code/session_01Lm1o2F73DjELdYC28V6NfN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds a new container/service plus supporting config/scripts; risk is limited to port exposure and ensuring the encryption key is set correctly.
> 
> **Overview**
> Adds the Homarr dashboard to the `theater` media stack via Docker Compose, exposing it on port `7575` and persisting data under `${APPDATA_DIR}/homarr`.
> 
> Introduces `HOMARR_SECRET_ENCRYPTION_KEY` (documented in `.env.example`) and a `generate-homarr-key.sh` helper to generate/update the key, updates NixOS firewall rules and `make_dirs.sh` to provision required directories, and adds `openssl` to system packages to support key generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2ce4826e2d3bf3f9046be1109d9cb1b43ceca52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->