### PR TITLE
Remove zeroclaw module import from theater home config

### DIFF
--- a/nix/hosts/theater/home.nix
+++ b/nix/hosts/theater/home.nix
@@ -8,7 +8,6 @@
       ../../modules/home/spicetify.nix
       ../../modules/home/theming/noctalia.nix
       ../../modules/home/media.nix
-      ../../modules/home/zeroclaw.nix
     ];
 
     gtk = {


### PR DESCRIPTION
https://claude.ai/code/session_01C7qf2pVxxcifATeFZGYnVP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line Nix config change that only affects one host’s Home Manager module imports.
> 
> **Overview**
> Removes the `../../modules/home/zeroclaw.nix` import from the `theater` Home Manager configuration (`nix/hosts/theater/home.nix`), so that module is no longer applied for that user.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16d30d270da867dcaa9784d1706cf393cb37b4ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->