### PR TITLE
Add video/render groups to theater user and pass GPU to Jellyfin

### DIFF
--- a/nix/hosts/theater/default.nix
+++ b/nix/hosts/theater/default.nix
@@ -25,7 +25,7 @@
   users.users.theater = {
     isNormalUser = true;
     shell = pkgs.zsh;
-    extraGroups = ["users" "wheel" "docker" "networkmanager"];
+    extraGroups = ["users" "wheel" "docker" "networkmanager" "video" "render"];
   };
 
   # Docker for media services

--- a/nix/hosts/theater/default.nix
+++ b/nix/hosts/theater/default.nix
@@ -91,6 +91,17 @@
     openssl
   ];
 
+  # Intel Quick Sync (Alder Lake-N) hardware acceleration
+  hardware.graphics = {
+    enable = true;
+    extraPackages = with pkgs; [
+      intel-media-driver # iHD driver for QSV
+      intel-compute-runtime # OpenCL for HDR tone-mapping
+      vpl-gpu-rt # Intel Video Processing Library
+    ];
+  };
+  environment.sessionVariables.LIBVA_DRIVER_NAME = "iHD";
+
   services.noctalia-shell.enable = true;
   services.power-profiles-daemon.enable = true;
   services.tailscale.enable = true;

--- a/nix/hosts/theater/docker-compose.yaml
+++ b/nix/hosts/theater/docker-compose.yaml
@@ -95,6 +95,8 @@ services:
     volumes:
       - ${APPDATA_DIR}/jellyfin:/config
       - ${DATA_DIR}/media:/data/media
+    devices:
+      - /dev/dri:/dev/dri
     restart: unless-stopped
 
   seerr:


### PR DESCRIPTION
Add theater user to video and render groups for GPU access, and pass
/dev/dri into the Jellyfin container to enable hardware-accelerated
transcoding.

https://claude.ai/code/session_01HRu2NDkWDaGJUCLtgePgTc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables host GPU/VA-API support and exposes `/dev/dri` to the Jellyfin container, which increases hardware access surface area and can impact media stack behavior if drivers or permissions are misconfigured.
> 
> **Overview**
> Adds GPU access for the `theater` host to support hardware-accelerated Jellyfin transcoding.
> 
> The `theater` user is added to the `video` and `render` groups, Intel Quick Sync/VA-API packages are enabled via `hardware.graphics` (with `LIBVA_DRIVER_NAME=iHD`), and the Jellyfin container is updated to mount `/dev/dri` for direct GPU device access.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09404be21716cdc2589557569944a1eaebe8666f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->