### PR TITLE
Add Intel OpenCL mod to Jellyfin container for HDR tone mapping

### DIFF
--- a/nix/hosts/theater/docker-compose.yaml
+++ b/nix/hosts/theater/docker-compose.yaml
@@ -92,6 +92,7 @@ services:
       - PUID=${PUID}
       - PGID=${PGID}
       - TZ=${TZ}
+      - DOCKER_MODS=linuxserver/mods:jellyfin-opencl-intel
     volumes:
       - ${APPDATA_DIR}/jellyfin:/config
       - ${DATA_DIR}/media:/data/media


### PR DESCRIPTION
The host has intel-compute-runtime but the Docker container lacked
OpenCL libraries, causing Jellyfin to fall back to CPU transcoding
for 4K HDR tone mapping.

https://claude.ai/code/session_01EciWMkqjGw7nXYRmKotjaC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single docker-compose env var change; primary risk is Jellyfin container startup/compatibility issues if the mod image changes or is unavailable.
> 
> **Overview**
> Adds `DOCKER_MODS=linuxserver/mods:jellyfin-opencl-intel` to the `jellyfin` service in `nix/hosts/theater/docker-compose.yaml` so the container includes Intel OpenCL libraries for hardware-accelerated HDR tone mapping/transcoding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13188840bb42ef388d17c2f24e9b70d316694695. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->